### PR TITLE
fallback meta data image url for og image 

### DIFF
--- a/src/Quintype/Seo/Story.php
+++ b/src/Quintype/Seo/Story.php
@@ -114,7 +114,7 @@ class Story extends Base
             'url' => $this->getCanonicalUrl(). "/". $this->card['id'],
             'site-name' => trim($this->config['title']),
             'description' => isset($this->cardSocialShare["message"])? $this->cardSocialShare["message"] : trim($this->getSocialDescription()),
-            'image' => isset($this->cardSocialShare["image"])? $this->getCardImageUrl() : $this->getHeroImageUrl(),
+            'image' => isset($this->cardSocialShare["image"]) && isset($this->cardSocialShare['image']['key']) ? $this->getCardImageUrl() : $this->getHeroImageUrl(),
         ];
 
         if (isset($this->cardSocialShare['image']['metadata'])) {


### PR DESCRIPTION
**Updated Story.php**
Added one more condition in getCardShareOgAttributes() , previously we only check for image is present or not in metadata , but the problem with that is if image is present but key not present within that. 
now i update the logic , instead of checking image only i added the image with key if both are present then execute getCardImageUrl() other execute getHeroImageUrl(). 