### PR TITLE
throwing error in getCardShareTwitterAttributes(), fixed it

### DIFF
--- a/src/Quintype/Seo/Story.php
+++ b/src/Quintype/Seo/Story.php
@@ -141,7 +141,7 @@ class Story extends Base
             'site' => $this->getTwitterSite(),
             'creator' => $this->getTwitterCreator(),
             'image' => [
-                'src' => isset($this->cardSocialShare["image"])? $this->getCardImageUrl() : $this->getHeroImageUrl(),
+                'src' => isset($this->cardSocialShare["image"]) && isset($this->cardSocialShare['image']['key']) ? $this->getCardImageUrl() : $this->getHeroImageUrl(),
             ],
         ];
 


### PR DESCRIPTION
For ticket - https://github.com/quintype/ace-support/issues/218,
The issue was, we only checking image is present or not in cardSocialShare['image'] , we did not checking for key present or not withing that cardSocialShare image(cardSocialShare['image']['key']). so it was throwing an error because the image was present in card and key was not present for that particular image.